### PR TITLE
Updating Presto instance to have SSL enabled 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,16 @@ RUN curl -Lo /usr/local/bin/presto https://repo1.maven.org/maven2/com/facebook/p
 
 COPY ["./etc", "/opt/presto/etc"]
 
-EXPOSE 8080
+RUN keytool \
+        -genkeypair \
+        -alias "presto" \
+        -keyalg RSA \
+        -keystore /opt/presto/etc/keystore.jks \
+        -validity 10000 \
+        -dname "CN=*.presto-ci.metabase.com, OU=Engineering, O=Metabase, L=San Francisco, S=CA, C=USA" \
+        -ext "SAN:c=DNS:localhost,IP:127.0.0.1,DNS:presto" \
+        -storepass metabase
+
+EXPOSE 8080 8443
 
 CMD ["/opt/presto/bin/launcher", "run"]

--- a/build-docker-image.sh
+++ b/build-docker-image.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+# builds this Docker image with the default tag
+
+docker build . -t metabase/presto-mb-ci
+

--- a/etc/catalog/a_checkin_every_15_seconds.properties
+++ b/etc/catalog/a_checkin_every_15_seconds.properties
@@ -1,0 +1,1 @@
+connector.name=memory

--- a/etc/catalog/a_checkin_every_86400_seconds.properties
+++ b/etc/catalog/a_checkin_every_86400_seconds.properties
@@ -1,0 +1,1 @@
+connector.name=memory

--- a/etc/catalog/a_checkin_every_900_seconds.properties
+++ b/etc/catalog/a_checkin_every_900_seconds.properties
@@ -1,0 +1,1 @@
+connector.name=memory

--- a/etc/catalog/avian_singles.properties
+++ b/etc/catalog/avian_singles.properties
@@ -1,0 +1,1 @@
+connector.name=memory

--- a/etc/catalog/geographical_tips.properties
+++ b/etc/catalog/geographical_tips.properties
@@ -1,0 +1,1 @@
+connector.name=memory

--- a/etc/catalog/half_valid_urls.properties
+++ b/etc/catalog/half_valid_urls.properties
@@ -1,0 +1,1 @@
+connector.name=memory

--- a/etc/catalog/places_cam_likes.properties
+++ b/etc/catalog/places_cam_likes.properties
@@ -1,0 +1,1 @@
+connector.name=memory

--- a/etc/catalog/sad_toucan_incidents.properties
+++ b/etc/catalog/sad_toucan_incidents.properties
@@ -1,0 +1,1 @@
+connector.name=memory

--- a/etc/catalog/test_data.properties
+++ b/etc/catalog/test_data.properties
@@ -1,0 +1,1 @@
+connector.name=memory

--- a/etc/catalog/test_data_with_time.properties
+++ b/etc/catalog/test_data_with_time.properties
@@ -1,0 +1,1 @@
+connector.name=memory

--- a/etc/catalog/tupac_sightings.properties
+++ b/etc/catalog/tupac_sightings.properties
@@ -1,0 +1,1 @@
+connector.name=memory

--- a/etc/config.properties
+++ b/etc/config.properties
@@ -5,3 +5,22 @@ query.max-memory=1GB
 query.max-memory-per-node=500MB
 discovery-server.enabled=true
 discovery.uri=http://localhost:8080
+
+# SSL related properties
+# refer to https://prestodb.io/docs/current/security/internal-communication.html
+node.internal-address-source=FQDN
+
+http-server.https.enabled=true
+http-server.https.port=8443
+# the keystore is generated in Dockerfile
+http-server.https.keystore.path=/opt/presto/etc/keystore.jks
+http-server.https.keystore.key=metabase
+
+# TODO: check if this is needed in single node
+# discovery.uri=https://<coordinator fqdn>:<https port>
+
+internal-communication.https.required=true
+
+internal-communication.https.keystore.path=/opt/presto/etc/keystore.jks
+internal-communication.https.keystore.key=metabase
+


### PR DESCRIPTION
(in addition to HTTP/insecure)

Adding versions of every catalog that have "-" replaced with "_" due to a bug
in the Presto JDBC driver (prestodb/presto#10739)

Exposing SSL port from Docker image

Adding convenient build script