### PR TITLE
Set node hostname to presto

### DIFF
--- a/etc/config.properties
+++ b/etc/config.properties
@@ -8,7 +8,10 @@ discovery.uri=http://localhost:8080
 
 # SSL related properties
 # refer to https://prestodb.io/docs/current/security/internal-communication.html
-node.internal-address-source=FQDN
+# disable FQDN hostname resolution (since we may be running on some other Docker executor, ex: in CI)
+#node.internal-address-source=FQDN
+# instead, hardcode the machine name to simply presto, which will always be made a valid hostname in all contexts
+node.internal-address=presto
 
 http-server.https.enabled=true
 http-server.https.port=8443


### PR DESCRIPTION
Hard code the node's host name to `presto` instead of using `hostname` resolution on the machine, since the "bare metal" hostname may vary between different environments (local, CI, etc.)