### PR TITLE
Presto server updates (again)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM openjdk:8
 
 MAINTAINER Jeff Evans <jeff.evans@metabase.com>
 
-ENV PRESTO_VERSION 0.186
+ENV PRESTO_VERSION 0.254
 
 RUN mkdir /opt/presto && \
     curl -LS https://repo1.maven.org/maven2/com/facebook/presto/presto-server/${PRESTO_VERSION}/presto-server-${PRESTO_VERSION}.tar.gz | tar -xz --strip-components=1 -C /opt/presto

--- a/etc/catalog/attempted_murders.properties
+++ b/etc/catalog/attempted_murders.properties
@@ -1,0 +1,1 @@
+connector.name=memory

--- a/etc/catalog/checkins.properties
+++ b/etc/catalog/checkins.properties
@@ -1,0 +1,1 @@
+connector.name=memory

--- a/etc/catalog/checkins_interval_15.properties
+++ b/etc/catalog/checkins_interval_15.properties
@@ -1,0 +1,1 @@
+connector.name=memory

--- a/etc/catalog/checkins_interval_86400.properties
+++ b/etc/catalog/checkins_interval_86400.properties
@@ -1,0 +1,1 @@
+connector.name=memory

--- a/etc/catalog/checkins_interval_900.properties
+++ b/etc/catalog/checkins_interval_900.properties
@@ -1,0 +1,1 @@
+connector.name=memory

--- a/etc/catalog/daily_bird_counts.properties
+++ b/etc/catalog/daily_bird_counts.properties
@@ -1,0 +1,1 @@
+connector.name=memory

--- a/etc/catalog/office_checkins.properties
+++ b/etc/catalog/office_checkins.properties
@@ -1,0 +1,1 @@
+connector.name=memory

--- a/etc/catalog/sample_dataset.properties
+++ b/etc/catalog/sample_dataset.properties
@@ -1,0 +1,1 @@
+connector.name=memory

--- a/etc/catalog/string_times.properties
+++ b/etc/catalog/string_times.properties
@@ -1,0 +1,1 @@
+connector.name=memory

--- a/etc/catalog/test_data_with_timezones.properties
+++ b/etc/catalog/test_data_with_timezones.properties
@@ -1,0 +1,1 @@
+connector.name=memory

--- a/etc/catalog/toucan_microsecond_incidents.properties
+++ b/etc/catalog/toucan_microsecond_incidents.properties
@@ -1,0 +1,1 @@
+connector.name=memory

--- a/etc/config.properties
+++ b/etc/config.properties
@@ -29,3 +29,5 @@ internal-communication.https.required=true
 internal-communication.https.keystore.path=/opt/presto/etc/keystore.jks
 internal-communication.https.keystore.key=metabase
 
+# as per https://github.com/prestodb/presto/issues/13097#issuecomment-555279730
+http-server.max-request-header-size=16MB


### PR DESCRIPTION
Increase version to 0.254

Set http-server.max-request-header-size=16MB to allow for large insert statements (ex: test data)

Adding many missing test catalogs